### PR TITLE
Fix readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -6,7 +6,7 @@ tags:
   - provider/datadog
 ---
 
-# Component: `datadog`
+# Component: `datadog-monitor`
 
 This component is responsible for provisioning Datadog monitors and assigning Datadog roles to the monitors.
 


### PR DESCRIPTION
## what
- Copy CHANGELOG.md to `src/CHANGELOG.md`
- Generate `src/README.md` from `README.yaml`

## why
- `atmos vendor` should get readme files
